### PR TITLE
fix(migrations): users delete_at type from timestamp to datetime

### DIFF
--- a/db/migrations/20191020211204_users.js
+++ b/db/migrations/20191020211204_users.js
@@ -7,7 +7,7 @@ exports.up = async knex => {
     table.string('password').notNullable()
     table.string('username').notNullable()
     table.timestamps(false, true)
-    table.timestamp('deleted_at').defaultTo(knex.fn.now())
+    table.datetime('deleted_at').defaultTo(knex.fn.now())
   })
 }
 


### PR DESCRIPTION
**DESCRIPTION**
The timestamp type was not allowing the timezone to be UTC, using
datetime does.